### PR TITLE
feat(users): implement own account deletion by user

### DIFF
--- a/src/controllers/usersController.js
+++ b/src/controllers/usersController.js
@@ -280,6 +280,51 @@ async function changePassword(req, res) {
   }
 }
 
+async function deleteUserAccount(req, res) {
+  req.log.debug("Delete user account request received", { userId: req.user?.userId });
+
+  try {
+    const { userId } = req.user;
+    const { password } = req.body;
+
+    if (!password) {
+      req.log.warn("User account deletion attempt with missing password", { userId });
+      return res.status(400).json({ error: "Password is required" });
+    }
+
+    const user = await findUserById(userId);
+
+    await verifyPassword(password, user.hashed_password);
+
+    req.log.info("Password verified for account deletion", { userId });
+    await db.query("DELETE FROM users WHERE id = $1", [userId]);
+    res.clearCookie("authToken");
+    req.log.info("User account deleted successfully", { userId });
+    res.status(204).send();
+  } catch (err) {
+    if (err instanceof NotFoundError) {
+      req.log.warn("User not found during profile update", { userId: req.user?.userId });
+      return res.status(err.statusCode).json({ error: err.message });
+    }
+
+    if (err instanceof UnauthorizedError) {
+      req.log.warn("User account deletion attempt with incorrect password", {
+        error: err.message,
+        userId: req.user?.userId,
+        stack: err.stack,
+      });
+      return res.status(err.statusCode).json({ error: "Incorrect password" });
+    }
+
+    req.log.error("User account deletion failed", {
+      error: err.message,
+      stack: err.stack,
+      userId: req.user?.userId,
+    });
+    res.status(500).json({ error: "Account deletion failed" });
+  }
+}
+
 module.exports = {
   registerUser,
   loginUser,
@@ -287,4 +332,5 @@ module.exports = {
   viewUserProfile,
   updateUserProfile,
   changePassword,
+  deleteUserAccount,
 };

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -14,6 +14,7 @@ const {
   logoutUser,
   updateUserProfile,
   changePassword,
+  deleteUserAccount,
 } = require("../controllers/usersController");
 
 const router = express.Router();
@@ -29,5 +30,7 @@ router.get("/profile", authenticateToken, requireAuth, viewUserProfile);
 router.put("/profile", authenticateToken, requireAuth, updateUserProfile);
 
 router.put("/password", authenticateToken, requireAuth, changePassword);
+
+router.delete("/profile", authenticateToken, requireAuth, deleteUserAccount);
 
 module.exports = router;

--- a/tests/routes/users.test.js
+++ b/tests/routes/users.test.js
@@ -423,4 +423,98 @@ describe("User routes", () => {
       expect(res.body).toHaveProperty("error", "Authentication required");
     });
   });
+
+  describe("DELETE /profile", () => {
+    let cookies;
+
+    beforeEach(async () => {
+      const registerRes = await registerUser({
+        email: "testuser@example.com",
+        password: "password123",
+      });
+      cookies = registerRes.headers["set-cookie"];
+    });
+
+    test("delete account with correct password", async () => {
+      const res = await request(app)
+        .delete(`${baseUrl}/profile`)
+        .set("Cookie", cookies)
+        .send({ password: "password123" });
+
+      expect(res.statusCode).toBe(204);
+      expect(res.headers["set-cookie"]).toBeDefined();
+      expect(res.headers["set-cookie"][0]).toMatch(/authToken=;/);
+
+      // Verify user is deleted from database
+      const user = await db.query("SELECT * FROM users WHERE email = 'testuser@example.com'");
+      expect(user.rows).toHaveLength(0);
+    });
+
+    test("delete account with incorrect password", async () => {
+      const res = await request(app)
+        .delete(`${baseUrl}/profile`)
+        .set("Cookie", cookies)
+        .send({ password: "wrongpassword" });
+
+      expect(res.statusCode).toBe(401);
+      expect(res.body).toHaveProperty("error", "Incorrect password");
+
+      // Verify user still exists
+      const user = await db.query("SELECT * FROM users WHERE email = 'testuser@example.com'");
+      expect(user.rows).toHaveLength(1);
+    });
+
+    test("delete account without password", async () => {
+      const res = await request(app).delete(`${baseUrl}/profile`).set("Cookie", cookies).send({});
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toHaveProperty("error", "Password is required");
+
+      // Verify user still exists
+      const user = await db.query("SELECT * FROM users WHERE email = 'testuser@example.com'");
+      expect(user.rows).toHaveLength(1);
+    });
+
+    test("delete account without authentication", async () => {
+      const res = await request(app).delete(`${baseUrl}/profile`).send({ password: "password123" });
+
+      expect(res.statusCode).toBe(401);
+      expect(res.body).toHaveProperty("error", "Authentication required");
+    });
+
+    test("cascade deletion of user data", async () => {
+      // Get user ID from existing user
+      const userProfile = await request(app).get(`${baseUrl}/profile`).set("Cookie", cookies);
+      const userId = userProfile.body.user.userId;
+
+      // Add a book and a review
+      await db.query("INSERT INTO books (google_books_id, title, authors) VALUES ($1, $2, $3)", [
+        "test-book-id",
+        "Test Book",
+        ["Test Author"],
+      ]);
+
+      await db.query("INSERT INTO reviews (user_id, book_id, rating, content) VALUES ($1, $2, $3, $4)", [
+        userId,
+        "test-book-id",
+        5,
+        "Great book!",
+      ]);
+
+      // Delete account
+      const deleteRes = await request(app)
+        .delete(`${baseUrl}/profile`)
+        .set("Cookie", cookies)
+        .send({ password: "password123" });
+
+      expect(deleteRes.statusCode).toBe(204);
+
+      // Verify user and related data are deleted
+      const user = await db.query("SELECT * FROM users WHERE email = 'testuser@example.com'");
+      expect(user.rows).toHaveLength(0);
+
+      const reviews = await db.query("SELECT * FROM reviews WHERE user_id = $1", [userId]);
+      expect(reviews.rows).toHaveLength(0);
+    });
+  });
 });


### PR DESCRIPTION
Implements user account self-deletion functionality.
- Uses req.user.userId (from JWT) to prevent deleting other accounts. 
- Requires authentication and password confirmation.
- Automatically removes all associated user data (reviews, suggestions, etc) due to database CASCADE constraints.
- Clears auth cookie on successful deletion.